### PR TITLE
Added: awaitEvent and awaitResult with timeout

### DIFF
--- a/src/test/java/io/vertx/ext/sync/test/SyncTest.java
+++ b/src/test/java/io/vertx/ext/sync/test/SyncTest.java
@@ -70,6 +70,16 @@ public class SyncTest extends VertxTestBase {
   public void testExecSyncMethodWithParamsAndHandlerInterface() throws Exception {
     runTest(getMethodName());
   }
+  
+  @Test
+  public void testExecSyncMethodWithNoParamsAndHandlerWithReturnNoTimeout() throws Exception {
+    runTest(getMethodName());
+  }
+  
+  @Test
+  public void testExecSyncMethodWithNoParamsAndHandlerWithReturnTimedout() throws Exception {
+    runTest(getMethodName());
+  }
 
   @Test
   public void testExecSyncMethodThatFails() throws Exception {
@@ -80,6 +90,16 @@ public class SyncTest extends VertxTestBase {
 
   @Test
   public void testReceiveEvent() throws Exception {
+    runTest(getMethodName());
+  }
+  
+  @Test
+  public void testReceiveEventTimedout() throws Exception {
+    runTest(getMethodName());
+  }
+  
+  @Test
+  public void testReceiveEventNoTimeout() throws Exception {
     runTest(getMethodName());
   }
 

--- a/src/test/java/io/vertx/ext/sync/test/TestVerticle.java
+++ b/src/test/java/io/vertx/ext/sync/test/TestVerticle.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 import static io.vertx.ext.sync.Sync.*;
 
+import static org.hamcrest.core.Is.*;
+
 /**
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -149,6 +151,20 @@ public class TestVerticle extends SyncVerticle {
     assertEquals("wibble", res);
     complete();
   }
+  
+  @Suspendable
+  protected void testExecSyncMethodWithNoParamsAndHandlerWithReturnNoTimeout() {
+    String res = awaitResult(h -> ai.methodWithNoParamsAndHandlerWithReturnTimeout(h, 1000), 2000);
+    assertEquals("wibble", res);
+    complete();
+  }
+  
+  @Suspendable
+  protected void testExecSyncMethodWithNoParamsAndHandlerWithReturnTimedout() {
+    String res = awaitResult(h -> ai.methodWithNoParamsAndHandlerWithReturnTimeout(h, 1000), 500);
+    assertNull(res);
+    complete();
+  }
 
   @Suspendable
   protected void testExecSyncMethodWithParamsAndHandlerInterface() {
@@ -179,6 +195,37 @@ public class TestVerticle extends SyncVerticle {
     long start = System.currentTimeMillis();
     long tid = awaitEvent(h -> vertx.setTimer(500, h));
     long end = System.currentTimeMillis();
+    assertTrue(end - start >= 500);
+    assertTrue(tid >= 0);
+
+    complete();
+  }
+    
+  @Suspendable
+  protected void testReceiveEventTimedout() {
+
+    long start = System.currentTimeMillis();
+    try {
+    	long tid = awaitEvent(h -> vertx.setTimer(500, h), 250);	
+    } catch(NullPointerException npe) {
+    	assertThat(npe, isA(NullPointerException.class));
+    } catch(Exception e) {
+    	assertTrue(false);
+    } finally {
+    	complete();	
+	}    
+  }
+  
+  @Suspendable
+  protected void testReceiveEventNoTimeout() {
+
+    long start = System.currentTimeMillis();
+    long tid = awaitEvent(h -> vertx.setTimer(500, h), 1000);
+    long end = System.currentTimeMillis();
+    
+    System.out.println(tid);
+    System.out.println(end);
+    
     assertTrue(end - start >= 500);
     assertTrue(tid >= 0);
 

--- a/src/test/java/io/vertx/ext/sync/test/TestVerticle.java
+++ b/src/test/java/io/vertx/ext/sync/test/TestVerticle.java
@@ -221,11 +221,7 @@ public class TestVerticle extends SyncVerticle {
 
     long start = System.currentTimeMillis();
     long tid = awaitEvent(h -> vertx.setTimer(500, h), 1000);
-    long end = System.currentTimeMillis();
-    
-    System.out.println(tid);
-    System.out.println(end);
-    
+    long end = System.currentTimeMillis();    
     assertTrue(end - start >= 500);
     assertTrue(tid >= 0);
 

--- a/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterface.java
+++ b/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterface.java
@@ -27,5 +27,7 @@ public interface AsyncInterface {
 
   void methodThatFails(String foo, Handler<AsyncResult<String>> resultHandler);
 
+  String methodWithNoParamsAndHandlerWithReturnTimeout(Handler<AsyncResult<String>> resultHandler, long timeout);
+
 
 }

--- a/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterfaceImpl.java
+++ b/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterfaceImpl.java
@@ -54,4 +54,13 @@ public class AsyncInterfaceImpl implements AsyncInterface {
     vertx.runOnContext(v -> resultHandler.handle(Future.failedFuture(new Exception(foo))));
   }
 
+  @Override
+  public String methodWithNoParamsAndHandlerWithReturnTimeout(Handler<AsyncResult<String>> resultHandler, long timeout) {
+	try {
+		Thread.sleep(timeout);
+	} catch(InterruptedException e) {
+	}
+    vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture("wibble")));
+    return "flooble";
+  }
 }


### PR DESCRIPTION
Hi

As I wanted to use the SyncVerticles but wanted to ensure an end I added myself a timeout to work with.

It is basically the same as the existing _Sync.awaitResult_ and _awaitEvent_ but runs with a milliseconds timeout. The old methods are still valid but now I can choose what I am looking for (forcing an end after some time).

Both have successful tests. Potentially both methods could be merged with a little more finesse but I wanted to wait if this PR does make sense to others, too.

Cheers
