### PR TITLE
Introduce Sync.awaitFiber to improve semantics around nested fiber calling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
   </parent>
 
   <artifactId>vertx-sync</artifactId>
-  <version>3.4.0-SNAPSHOT</version>
+  <version>3.3.3.F</version>
 
   <properties>
-    <stack.version>3.4.0-SNAPSHOT</stack.version>
+    <stack.version>3.3.3</stack.version>
 
     <quasar-core.version>0.7.5</quasar-core.version>
     <quasar-maven-plugin.version>0.7.3</quasar-maven-plugin.version>

--- a/src/test/java/io/vertx/ext/sync/test/SyncTest.java
+++ b/src/test/java/io/vertx/ext/sync/test/SyncTest.java
@@ -70,12 +70,12 @@ public class SyncTest extends VertxTestBase {
   public void testExecSyncMethodWithParamsAndHandlerInterface() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testExecSyncMethodWithNoParamsAndHandlerWithReturnNoTimeout() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testExecSyncMethodWithNoParamsAndHandlerWithReturnTimedout() throws Exception {
     runTest(getMethodName());
@@ -86,18 +86,28 @@ public class SyncTest extends VertxTestBase {
     runTest(getMethodName());
   }
 
+  @Test
+  public void testExecNestedSyncMethods() throws Exception {
+    runTest(getMethodName());
+  }
+
+  @Test
+  public void testExecSyncWithAwaitFiber() throws Exception {
+    runTest(getMethodName());
+  }
+
   // Test receive single event
 
   @Test
   public void testReceiveEvent() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testReceiveEventTimedout() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testReceiveEventNoTimeout() throws Exception {
     runTest(getMethodName());


### PR DESCRIPTION
`Sync.awaitFiber` runs the `consumer` argument in a fiber. It does this hackily, by creating a `fiberHandler` that handles a `null`. A better implementation is urged.