### PR TITLE
Instrumenting fixes

### DIFF
--- a/src/main/java/io/vertx/ext/sync/Sync.java
+++ b/src/main/java/io/vertx/ext/sync/Sync.java
@@ -37,6 +37,7 @@ public class Sync {
     try {
       return new AsyncAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -64,6 +65,7 @@ public class Sync {
     try {
       return new AsyncAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             fiberHandler((Handler<Void> ignored) -> {
@@ -93,6 +95,7 @@ public class Sync {
     try {
       return new AsyncAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -120,6 +123,7 @@ public class Sync {
     try {
       return new HandlerAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -147,6 +151,7 @@ public class Sync {
     try {
       return new HandlerAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);

--- a/src/main/java/io/vertx/ext/sync/impl/AsyncAdaptor.java
+++ b/src/main/java/io/vertx/ext/sync/impl/AsyncAdaptor.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.sync.impl;
 
 import co.paralleluniverse.fibers.FiberAsync;
+import co.paralleluniverse.fibers.Suspendable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
@@ -11,6 +12,7 @@ import io.vertx.core.Handler;
 public abstract class AsyncAdaptor<T> extends FiberAsync<T, Throwable> implements Handler<AsyncResult<T>>  {
 
   @Override
+  @Suspendable
   public void handle(AsyncResult<T> res) {
     if (res.succeeded()) {
       asyncCompleted(res.result());

--- a/src/test/java/io/vertx/ext/sync/test/SyncTest.java
+++ b/src/test/java/io/vertx/ext/sync/test/SyncTest.java
@@ -70,12 +70,12 @@ public class SyncTest extends VertxTestBase {
   public void testExecSyncMethodWithParamsAndHandlerInterface() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testExecSyncMethodWithNoParamsAndHandlerWithReturnNoTimeout() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testExecSyncMethodWithNoParamsAndHandlerWithReturnTimedout() throws Exception {
     runTest(getMethodName());
@@ -86,18 +86,28 @@ public class SyncTest extends VertxTestBase {
     runTest(getMethodName());
   }
 
+  @Test
+  public void testExecNestedSyncMethods() throws Exception {
+    runTest(getMethodName());
+  }
+
+  @Test
+  public void testExecSyncWithAwaitFiber() throws Exception {
+    runTest(getMethodName());
+  }
+
   // Test receive single event
 
   @Test
   public void testReceiveEvent() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testReceiveEventTimedout() throws Exception {
     runTest(getMethodName());
   }
-  
+
   @Test
   public void testReceiveEventNoTimeout() throws Exception {
     runTest(getMethodName());


### PR DESCRIPTION
 - Create tests to demonstrate nested awaits.
 - Create a better primitive, `awaitFiber`, that calls `awaitResult`'s argument in a Fiber.
 - Add `@Suspendable` to the interface implementations. This fixes the production issue I experienced where callsites were marked as uninstrumented in nested `awaitResult` calls:

```
WARNING: Uninstrumented methods (marked '**') or call-sites (marked '!!') detected on the call stack: 
	at io.vertx.ext.sync.Sync.awaitFiber(java.util.function.Consumer) (Sync.java:78 bci: 113) !! (instrumented suspendable calls at: [])
```