### PR TITLE
Rework of the test cases for awaitResult and timeouts

### DIFF
--- a/src/main/java/io/vertx/ext/sync/Sync.java
+++ b/src/main/java/io/vertx/ext/sync/Sync.java
@@ -37,6 +37,7 @@ public class Sync {
     try {
       return new AsyncAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -49,7 +50,7 @@ public class Sync {
       throw new VertxException(t);
     }
   }
-  
+
   /**
    * Invoke an asynchronous operation and obtain the result synchronous.
    * The fiber will be blocked until the result is available. No kernel thread is blocked.
@@ -64,6 +65,7 @@ public class Sync {
     try {
       return new AsyncAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -92,6 +94,7 @@ public class Sync {
     try {
       return new HandlerAdaptor<T>() {
         @Override
+        @Suspendable
         protected void requestAsync() {
           try {
             consumer.accept(this);
@@ -104,7 +107,7 @@ public class Sync {
       throw new VertxException(t);
     }
   }
-  
+
   /**
    * Receive a single event from a handler synchronously.
    * The fiber will be blocked until the event occurs. No kernel thread is blocked.
@@ -118,6 +121,7 @@ public class Sync {
   public static <T> T awaitEvent(Consumer<Handler<T>> consumer, long timeout) {
     try {
       return new HandlerAdaptor<T>() {
+        @Suspendable
         @Override
         protected void requestAsync() {
           try {

--- a/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterface.java
+++ b/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterface.java
@@ -27,7 +27,5 @@ public interface AsyncInterface {
 
   void methodThatFails(String foo, Handler<AsyncResult<String>> resultHandler);
 
-  String methodWithNoParamsAndHandlerWithReturnTimeout(Handler<AsyncResult<String>> resultHandler, long timeout);
-
 
 }

--- a/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterfaceImpl.java
+++ b/src/test/java/io/vertx/ext/sync/testmodel/AsyncInterfaceImpl.java
@@ -54,13 +54,4 @@ public class AsyncInterfaceImpl implements AsyncInterface {
     vertx.runOnContext(v -> resultHandler.handle(Future.failedFuture(new Exception(foo))));
   }
 
-  @Override
-  public String methodWithNoParamsAndHandlerWithReturnTimeout(Handler<AsyncResult<String>> resultHandler, long timeout) {
-	try {
-		Thread.sleep(timeout);
-	} catch(InterruptedException e) {
-	}
-    vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture("wibble")));
-    return "flooble";
-  }
 }


### PR DESCRIPTION
[Quasar and `Thread.sleep` do not play well together](http://docs.paralleluniverse.co/quasar/#thread-blocking) so this PR clarifies how `awaitEvent` deals with timeouts by using a Quasar `Strand` to sleep.

Along the way I discovered that:

1. when the operation completes before the timeout, `awaitResult` returns quickly as we would expect, but
2. when the operation takes longer (see the longer `Strand.sleep` compared to the `awaitResult` timeout) then `awaitResult` does not return right after the timeout but waits for the operation to finish. While the return value of `awaitResult` is correct, it may block the event loop for a loooong time.

Interestingly `testReceiveEventTimedout` and `testReceiveEventNoTimeout` suggest the same behavior for `awaitEvent`.

Note that I may be wrong in my understanding, so I welcome other reviews and investigations.

Reported in #24 