### PR TITLE
Upgrade to Quasar 0.7.10 (last JDK8-compliant release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
 
-    <quasar-core.version>0.7.5</quasar-core.version>
-    <quasar-maven-plugin.version>0.7.3</quasar-maven-plugin.version>
+    <quasar-core.version>0.7.10</quasar-core.version>
+    <quasar-maven-plugin.version>0.7.9</quasar-maven-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Note: the Maven plugin is not maintained anymore, 0.7.9 was the last version.