### PR TITLE
Unit tests to reproduce NPE in the awaitResult() method from Sync class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,25 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      
+      <!-- proxy vertx -->
+      <!-- =======  TODO ====== -->
+      <!-- TODO: WARNING :      -->
+      <!--  -->
+      <!-- 1ER ISSUE: with vertx-codegen and vertx-service-proxy 3.6.0-SNAPSHOT, no class is generated -->
+      <!-- Work around: we force to use vertx-codegen and vertx-service-proxy 3.5.4 -->
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-codegen</artifactId>
+        <version>3.5.4</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-service-proxy</artifactId>
+        <version>3.5.4</version>
+        <classifier>processor</classifier>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -95,6 +114,47 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    
+    
+    
+    <dependency>
+		<groupId>io.vertx</groupId>
+		<artifactId>vertx-mongo-client</artifactId>
+		<scope>test</scope>
+	</dependency>
+	<!-- mongo in memory -->
+	<dependency>
+		<groupId>de.bwaldvogel</groupId>
+		<artifactId>mongo-java-server</artifactId>
+		<version>1.8.0</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>de.bwaldvogel</groupId>
+		<artifactId>mongo-java-server-memory-backend</artifactId>
+		<version>1.8.0</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.assertj</groupId>
+		<artifactId>assertj-core</artifactId>
+		<version>3.11.1</version>
+		<scope>test</scope>
+	</dependency>
+	
+	<!-- proxy vertx -->
+	<dependency>
+	  <groupId>io.vertx</groupId>
+	  <artifactId>vertx-codegen</artifactId>
+	  <scope>provided</scope>
+	</dependency>
+	<dependency>
+	  <groupId>io.vertx</groupId>
+	  <artifactId>vertx-service-proxy</artifactId>
+	  <classifier>processor</classifier>
+	</dependency>
+    
+    
   </dependencies>
 
   <build>
@@ -105,7 +165,7 @@
              as per http://maven.apache.org/plugins/maven-dependency-plugin/properties-mojo.html -->
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10</version>
           <executions>
             <execution>
               <id>getClasspathFilenames</id>
@@ -115,6 +175,60 @@
             </execution>
           </executions>
         </plugin>
+
+		<!--This plugin's configuration is used to store Eclipse m2e settings 
+		only. It has no influence on the Maven build itself. -->
+		<plugin>
+			<groupId>org.eclipse.m2e</groupId>
+			<artifactId>lifecycle-mapping</artifactId>
+			<version>1.0.0</version>
+			<configuration>
+				<lifecycleMappingMetadata>
+					<pluginExecutions>
+						<pluginExecution>
+							<pluginExecutionFilter>
+								<groupId>org.codehaus.mojo</groupId>
+								<artifactId>buildhelper-maven-plugin</artifactId>
+								<versionRange>[1.8,)</versionRange>
+								<goals>
+									<goal>add-test-source</goal>
+								</goals>
+							</pluginExecutionFilter>
+							<action>
+								<execute />
+							</action>
+						</pluginExecution>
+						<pluginExecution>
+							<pluginExecutionFilter>
+								<groupId>com.vlkan</groupId>
+								<artifactId>quasar-maven-plugin</artifactId>
+								<versionRange>[0.7.9,)</versionRange>
+								<goals>
+									<goal>instrument</goal>
+								</goals>
+							</pluginExecutionFilter>
+							<action>
+								<ignore />
+							</action>
+						</pluginExecution>
+						<pluginExecution>
+							<pluginExecutionFilter>
+								<groupId>org.apache.maven.plugins</groupId>
+								<artifactId>maven-dependency-plugin</artifactId>
+								<versionRange>[2.10,)</versionRange>
+								<goals>
+									<goal>copy</goal>
+									<goal>properties</goal>
+								</goals>
+							</pluginExecutionFilter>
+							<action>
+								<execute />
+							</action>
+						</pluginExecution>
+					</pluginExecutions>
+				</lifecycleMappingMetadata>
+			</configuration>
+		</plugin>
 
       </plugins>
     </pluginManagement>
@@ -153,13 +267,13 @@
            as per http://maven.apache.org/plugins/maven-dependency-plugin/properties-mojo.html -->
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
         <executions>
           <execution>
             <id>getClasspathFilenames</id>
             <goals>
               <goal>properties</goal>
             </goals>
+            <phase>initialize</phase>
           </execution>
         </executions>
       </plugin>
@@ -182,6 +296,25 @@
           <!--<forkCount>1</forkCount>-->
           <!--<reuseForks>true</reuseForks>-->
         </configuration>
+      </plugin>
+      
+      <plugin>
+		<groupId>org.codehaus.mojo</groupId>
+		  <artifactId>build-helper-maven-plugin</artifactId>
+		  <executions>
+		     <execution>
+		        <id>add-test-source</id>
+		        <phase>generate-test-sources</phase>
+		        <goals>
+		           <goal>add-test-source</goal>
+		        </goals>
+		        <configuration>
+		          <sources>
+		            <source>${project.build.directory}/generated-test-sources/tests-annotations/</source>
+		          </sources>
+		        </configuration>
+		     </execution>
+		  </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/io/vertx/ext/sync/npe/UserDaoTest.java
+++ b/src/test/java/io/vertx/ext/sync/npe/UserDaoTest.java
@@ -1,0 +1,131 @@
+package io.vertx.ext.sync.npe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.sync.Sync;
+import io.vertx.ext.sync.npe.service.user.UserDao;
+import io.vertx.ext.sync.npe.verticle.DaoSyncVerticleForTesting;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class UserDaoTest 
+{
+	private static final Logger LOGGER = LoggerFactory.getLogger(UserDaoTest.class);
+	
+	private static MongoServer server;
+	
+	private static InetSocketAddress serverAddress;
+	
+	private static DaoSyncVerticleForTesting verticle;
+	
+	private static Vertx vertx;
+	
+	private static MongoClient client;
+	
+	
+	@BeforeClass
+	public static void setUp(final TestContext testContext) 
+	{
+	    // log.info("@BeforeAll - executes once before all test methods in this class");
+		server = new MongoServer(new MemoryBackend());
+
+        // bind on a random local port
+        serverAddress = server.bind();
+        
+        final String dbName = UserDaoTest.class.getSimpleName();
+        final String host = serverAddress.getHostName();
+        final int port = serverAddress.getPort();
+
+        VertxOptions options = new VertxOptions();
+ 		if (java.lang.management.ManagementFactory.getRuntimeMXBean().
+ 			    getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
+ 		{
+ 			options.setBlockedThreadCheckInterval(1_000_000L);
+ 		}
+        vertx = Vertx.vertx(options);
+        
+        verticle = new DaoSyncVerticleForTesting(dbName, host, port);
+        client = MongoClient.createNonShared(vertx, verticle.createMongoConfiguration());
+        
+        LOGGER.info("Starting memory mongo server: " + host + ":" + port + "/" + dbName);
+        
+        Thread.currentThread().setName("JUNIT");
+        final Async async = testContext.async();
+        
+        vertx.deployVerticle(verticle, new Handler<AsyncResult<String>>()
+		{
+			@Override
+			public void handle(AsyncResult<String> deployVerticleEvent) 
+			{
+				if (deployVerticleEvent.succeeded())
+				{
+					async.complete();
+				}
+				else
+				{
+					testContext.fail(deployVerticleEvent.cause());
+					async.complete();
+				}
+			}
+		});
+	}
+	
+	
+	@AfterClass
+	public static void setDown(final TestContext testContext) throws Exception
+	{
+		if (client != null)
+		{
+			client.close();
+		}
+
+		try
+		{
+			if (verticle != null)
+			{
+				verticle.stop();
+			}
+		}
+		finally
+		{
+			if (server != null)
+			{
+				server.stopListenting();
+				server.shutdownNow();
+			}
+		}
+	}
+
+	@Test
+	public void testFindAll(final TestContext testContext) throws Exception
+	{
+		Async async = testContext.async();
+		final UserDao userDaoProxy = UserDao.createProxy(vertx, UserDao.SERVICE_ADDRESS);
+		final List<JsonObject> users = Sync.awaitResult(h -> userDaoProxy.findAll(h));
+
+		testContext.verify(h -> {
+			assertThat(Thread.currentThread().getName()).isEqualTo("JUNIT");
+			assertThat(users.size()).isEqualTo(2);
+			async.complete();
+		});
+	}
+}

--- a/src/test/java/io/vertx/ext/sync/npe/model/User.java
+++ b/src/test/java/io/vertx/ext/sync/npe/model/User.java
@@ -1,0 +1,65 @@
+package io.vertx.ext.sync.npe.model;
+
+import java.io.Serializable;
+
+/**
+ * User of the application.
+ */
+public class User implements Serializable 
+{
+	private static final long serialVersionUID = 1L;
+	
+	private String id;
+	
+	private String familyName;
+
+	private String givenName;
+	
+	private String email;
+	
+	public String getId() 
+	{
+		return id;
+	}
+
+	public void setId(String id) 
+	{
+		this.id = id;
+	}
+
+	public String getFamilyName()
+	{
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName)
+	{
+		this.familyName = familyName;
+	}
+
+	public String getGivenName()
+	{
+		return givenName;
+	}
+
+	public void setGivenName(String givenName)
+	{
+		this.givenName = givenName;
+	}
+	
+	public String getEmail()
+	{
+		return email;
+	}
+
+	public void setEmail(final String email)
+	{
+		this.email = email;
+	}
+
+	@Override
+	public String toString() 
+	{
+		return "User [id=" + id + ", familyName=" + familyName + ", givenName=" + givenName + ", email=" + email + "]";
+	}
+}

--- a/src/test/java/io/vertx/ext/sync/npe/service/user/UserDao.java
+++ b/src/test/java/io/vertx/ext/sync/npe/service/user/UserDao.java
@@ -1,0 +1,33 @@
+package io.vertx.ext.sync.npe.service.user;
+
+import java.util.List;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.ProxyIgnore;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+@ProxyGen
+public interface UserDao
+{
+	static final String SERVICE_ADDRESS = "dao.user";
+	
+	static UserDao create(Vertx vertx, JsonObject config) 
+	{
+		return new UserDaoImpl(vertx, config);
+	}
+
+	static UserDao createProxy(Vertx vertx, String address) 
+	{
+		return new UserDaoVertxEBProxy(vertx, address);
+	}
+	
+	void findAll(Handler<AsyncResult<List<JsonObject>>> result);
+	
+	void loadById(String id, Handler<AsyncResult<JsonObject>> result);
+	
+	@ProxyIgnore
+	void close();
+}

--- a/src/test/java/io/vertx/ext/sync/npe/service/user/UserDaoImpl.java
+++ b/src/test/java/io/vertx/ext/sync/npe/service/user/UserDaoImpl.java
@@ -1,0 +1,87 @@
+package io.vertx.ext.sync.npe.service.user;
+
+import java.io.Serializable;
+import java.util.List;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.sync.Sync;
+import io.vertx.serviceproxy.ServiceException;
+
+public class UserDaoImpl implements UserDao, Serializable
+{
+	public static final String USER_COLLECTION_NAME = "user";
+
+	private static final long serialVersionUID = 1L;
+	
+	private final JsonObject config;
+
+	private final MongoClient mongoClient;
+	
+	/**
+	 * Implementation du service W2UserDao.
+	 * 
+	 * @param vertx référence vers le verticle DAO.
+	 * @param config configuration de l'accès à la base de données MongoDB.
+	 */
+	public UserDaoImpl(final Vertx vertx, final JsonObject config)
+	{
+		this.config = config;
+		mongoClient = MongoClient.createNonShared(vertx, config);
+	}
+	
+	@Override
+	public void findAll(final Handler<AsyncResult<List<JsonObject>>> result) 
+	{
+		try
+		{
+			final List<JsonObject> results = Sync.awaitResult(h -> mongoClient.find(USER_COLLECTION_NAME, new JsonObject(), h));
+			result.handle(Future.succeededFuture(results));
+		}
+		catch (VertxException ve)
+		{
+			result.handle(ServiceException.fail(400, ve.getMessage()));
+		}
+	}
+	
+	@Override
+	public void loadById(final String id, final Handler<AsyncResult<JsonObject>> result)
+	{
+		try 
+		{
+			// _id
+			mongoClient.findOne(USER_COLLECTION_NAME, new JsonObject().put("_id", id), new FindOptions().toJson(), new Handler<AsyncResult<JsonObject>>(){
+				@Override
+				public void handle(AsyncResult<JsonObject> event) 
+				{
+					if (event.succeeded() && event.result() != null)
+					{
+						final JsonObject json = event.result();
+						result.handle(Future.succeededFuture(json));
+					}
+					else
+					{
+						result.handle(ServiceException.fail(403, "User " + id + " not found"));
+					}
+				}
+			});
+			
+		} 
+		catch (Exception e) 
+		{
+			result.handle(ServiceException.fail(404, "User " + id + " not found"));
+		}
+	}
+	
+	@Override
+	public void close() 
+	{
+		mongoClient.close();
+	}
+}

--- a/src/test/java/io/vertx/ext/sync/npe/service/user/package-info.java
+++ b/src/test/java/io/vertx/ext/sync/npe/service/user/package-info.java
@@ -1,0 +1,5 @@
+@ModuleGen(name = "user-dao", groupPackage = "io.vertx.ext.sync.npe.service.user")
+
+package io.vertx.ext.sync.npe.service.user;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/test/java/io/vertx/ext/sync/npe/verticle/AbstractSyncVerticle.java
+++ b/src/test/java/io/vertx/ext/sync/npe/verticle/AbstractSyncVerticle.java
@@ -1,0 +1,113 @@
+package io.vertx.ext.sync.npe.verticle;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.Suspendable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.sync.Sync;
+import io.vertx.ext.sync.SyncVerticle;
+
+public abstract class AbstractSyncVerticle extends SyncVerticle
+{
+	@Override
+	public void start(final Future<Void> startFuture) throws Exception 
+	{
+		final Future<Void> onStartingFuture = Future.future();
+		onStartingFuture.setHandler(new Handler<AsyncResult<Void>>() 
+		{
+			@Override
+			public void handle(final AsyncResult<Void> onStartingFutureEvent) 
+			{
+				if (onStartingFutureEvent.succeeded())
+				{
+					startFuture.complete();
+				}
+				else
+				{
+					startFuture.fail(onStartingFutureEvent.cause());
+				}
+			}
+		});		
+		
+		instanceScheduler = Sync.getContextScheduler();
+		new Fiber<Void>(instanceScheduler, () -> {
+			try 
+			{
+				onStarting(onStartingFuture);
+			} 
+			catch (final Throwable t) 
+			{
+				startFuture.fail(t);
+			}
+		}).start();
+	}
+
+	@Override
+	public void stop(Future<Void> stopFuture) throws Exception 
+	{
+		final Future<Void> onStopingFuture = Future.future();
+		onStopingFuture.setHandler(new Handler<AsyncResult<Void>>() 
+		{
+			@Override
+			public void handle(final AsyncResult<Void> onStopingFutureEvent) 
+			{
+				if (onStopingFutureEvent.succeeded())
+				{
+					stopFuture.complete();
+				}
+				else
+				{
+					stopFuture.fail(onStopingFutureEvent.cause());
+				}
+			}
+		});		
+		
+		new Fiber<Void>(instanceScheduler, () -> {
+			try 
+			{
+				onStoping(onStopingFuture);
+			} 
+			catch (final Throwable t) 
+			{
+				stopFuture.fail(t);
+			} 
+			finally 
+			{
+				Sync.removeContextScheduler();
+			}
+		}).start();
+	}
+
+	/**
+	 * Override this method in your verticle
+	*/
+	@Override
+	@Suspendable
+	public final void start() throws Exception 
+	{
+		// do nothing
+	}
+	
+	/**
+	 * Optionally override this method in your verticle if you have cleanup to do
+	 */
+	@Override
+	@Suspendable
+	public final void stop() throws Exception 
+	{
+		// do nothing
+	}
+	
+	@Suspendable
+	protected void onStarting(final Future<Void> onStartingFuture)
+	{
+		onStartingFuture.complete();
+	}
+
+	@Suspendable
+	protected void onStoping(final Future<Void> onStopingFuture)
+	{
+		onStopingFuture.complete();
+	}
+}

--- a/src/test/java/io/vertx/ext/sync/npe/verticle/DaoSyncVerticle.java
+++ b/src/test/java/io/vertx/ext/sync/npe/verticle/DaoSyncVerticle.java
@@ -1,0 +1,197 @@
+package io.vertx.ext.sync.npe.verticle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import com.mongodb.MongoException;
+
+import io.vertx.ext.sync.npe.model.User;
+import io.vertx.ext.sync.npe.service.user.UserDao;
+import io.vertx.ext.sync.npe.service.user.UserDaoImpl;
+import io.vertx.ext.sync.npe.verticle.AbstractSyncVerticle;
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.Suspendable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.VertxException;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.sync.Sync;
+import io.vertx.serviceproxy.ServiceBinder;
+
+public class DaoSyncVerticle extends AbstractSyncVerticle 
+{
+	private static final Logger LOGGER = LoggerFactory.getLogger(DaoSyncVerticle.class);
+	
+	private final Collection<MessageConsumer<JsonObject>> serviceConsumers = new ArrayList<>(); 
+
+	private ServiceBinder serviceBinder;
+	
+	private MongoClient mongoClient;
+	
+	private UserDaoImpl userDao;
+	
+	@Suspendable
+	@Override
+	protected void onStarting(final Future<Void> onStartingFuture) 
+	{
+		try
+		{
+			LOGGER.info("Initializing DaoSyncVerticle ...");
+			
+			serviceBinder = new ServiceBinder(vertx);
+			
+			final JsonObject config = createMongoConfiguration();
+			registerUserDao(config);
+			
+			mongoClient = MongoClient.createNonShared(vertx, config);
+
+			new Fiber<Void>(() -> {
+				Void res = Sync.awaitResult(h -> createMongoCollectionsAndCreateIndexesIfNeeded(h));
+				res = Sync.awaitResult(h -> initUserDataIfNeeded(h));
+				res = Sync.awaitResult(h -> afterMongoStarting(h));
+			}).start().get();
+			
+			LOGGER.info("DaoSyncVerticle starts with success.   [ OK ]");
+			onStartingFuture.complete();
+		}
+		catch (MongoException | VertxException | ExecutionException | InterruptedException me)
+		{
+			LOGGER.info("Fail to start DaoSyncVerticle: ", me);
+			onStartingFuture.fail(me);
+		}
+	}
+	
+	@Suspendable
+	@Override
+	protected void onStoping(final Future<Void> onStopingFuture) 
+	{
+		if (serviceBinder != null)
+		{
+			for(MessageConsumer<JsonObject> serviceConsumer : serviceConsumers)
+			{
+				serviceBinder.unregister(serviceConsumer);
+			}
+		}
+		
+		if (mongoClient != null)
+		{
+			mongoClient.close();
+		}
+		
+		onStopingFuture.complete();
+	}
+	
+	protected JsonObject createMongoConfiguration() 
+	{
+		String user = System.getProperty("userdb", null);
+		String mdp = System.getProperty("mdpdb", null);
+		String server = System.getProperty("serverdb", "192.168.0.2");
+		String port = System.getProperty("portdb", "27017");
+		String name = System.getProperty("namedb", "vertx-sync");
+		
+		
+		if (user != null && mdp != null)
+		{
+			LOGGER.info("Connecting to mongodb://" + user + ":******@" + server + ":" + port + "/" + name);
+		}
+		else
+		{
+			LOGGER.info("Connecting to mongodb://" + server + ":" + port + "/" + name);
+		}
+		
+		return new JsonObject()
+	        .put("connection_string", String.format("mongodb://%s%s:%s/%s", ((user != null && mdp != null) ? user + ":" + mdp + "@" : ""), server, port.toString(), name))
+	        .put("db_name", name);
+	}
+
+	protected void createMongoCollectionsAndCreateIndexesIfNeeded(final Handler<AsyncResult<Void>> result) 
+	{
+		Void res;
+
+		try
+		{
+			final List<String> collections = Sync.awaitResult(h -> mongoClient.getCollections(h));
+			if (!collections.contains(UserDaoImpl.USER_COLLECTION_NAME))
+			{
+				res = Sync.awaitResult(h -> mongoClient.createCollection(UserDaoImpl.USER_COLLECTION_NAME, h));
+				
+				final JsonObject jsonObjectForCreateIndexOnEmail = new JsonObject().put("email", 1).put("unique", true);
+				res = Sync.awaitResult(h -> mongoClient.createIndex(UserDaoImpl.USER_COLLECTION_NAME, jsonObjectForCreateIndexOnEmail, h));
+			}
+			
+			result.handle(Future.succeededFuture());
+		}
+		catch (Exception e)
+		{
+			result.handle(Future.failedFuture(e));
+		}
+	}
+
+	protected void initUserDataIfNeeded(final Handler<AsyncResult<Void>> result) 
+	{
+		final User julienPongeUser = new User();
+		julienPongeUser.setFamilyName("PONGE");
+		julienPongeUser.setGivenName("Julien");
+		julienPongeUser.setEmail("julien@ponge.org");
+		
+		final User julienVietUser = new User();
+		julienVietUser.setFamilyName("VIET");
+		julienVietUser.setGivenName("Julien");
+		julienVietUser.setEmail("julien@julienviet.com");
+		
+		try
+		{
+			String userId = Sync.awaitResult(h -> mongoClient.save(UserDaoImpl.USER_COLLECTION_NAME, serializeToJson(julienPongeUser), h));
+			julienPongeUser.setId(userId);
+			
+			userId = Sync.awaitResult(h -> mongoClient.save(UserDaoImpl.USER_COLLECTION_NAME, serializeToJson(julienVietUser), h));
+			julienVietUser.setId(userId);
+			
+			result.handle(Future.succeededFuture());
+		}
+		catch (Exception e)
+		{
+			result.handle(Future.failedFuture(e));
+		}
+	}
+	
+	protected void afterMongoStarting(final Handler<AsyncResult<Void>> result) 
+	{
+		result.handle(Future.succeededFuture());
+	}
+	
+	private void registerUserDao(final JsonObject config) 
+	{
+		final UserDao currUserDao = UserDao.create(this.vertx, config);
+		
+		serviceConsumers.add(serviceBinder
+			.setAddress(UserDao.SERVICE_ADDRESS)
+			.register(UserDao.class, currUserDao)
+		);
+		this.userDao = (UserDaoImpl)currUserDao;
+		LOGGER.info("user dao service   [ OK ]");
+	}
+	
+	private JsonObject serializeToJson(User user) 
+	{
+		final JsonObject json = new JsonObject();
+		
+		json.put("familyName", user.getFamilyName());
+		json.put("givenName", user.getGivenName());
+		json.put("email", user.getEmail());
+		
+		if (user.getId() != null && !"".equals(user.getId()))
+		{
+			json.put("_id", user.getId());
+		}
+		
+		return json;
+	}
+}

--- a/src/test/java/io/vertx/ext/sync/npe/verticle/DaoSyncVerticleForTesting.java
+++ b/src/test/java/io/vertx/ext/sync/npe/verticle/DaoSyncVerticleForTesting.java
@@ -1,0 +1,39 @@
+package io.vertx.ext.sync.npe.verticle;
+
+import co.paralleluniverse.fibers.Suspendable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+
+public class DaoSyncVerticleForTesting extends DaoSyncVerticle 
+{
+	private final String dbName;
+	
+	private final String serverHostName;
+	
+	private final int serverPort;
+
+	public DaoSyncVerticleForTesting(final String dbName, final String serverHostName, final int serverPort) 
+	{
+		super();
+		this.dbName = dbName;
+		this.serverHostName = serverHostName;
+		this.serverPort = serverPort;
+	}
+	
+	@Override
+	public JsonObject createMongoConfiguration() 
+	{
+		return new JsonObject()
+			.put("connection_string", "mongodb://" + serverHostName + ":" + serverPort)
+		    .put("db_name", dbName + System.currentTimeMillis());
+	}
+	
+	@Suspendable
+	@Override
+	protected void afterMongoStarting(final Handler<AsyncResult<Void>> result) 
+	{
+		result.handle(Future.succeededFuture());
+	}
+}


### PR DESCRIPTION
Hello @vietj, @jponge, 

this new pull request reproduces two issues with vertx 3.6.0-SNAPSHOT :
  1) with vertx-codegen and vertx-service-proxy 3.6.0-SNAPSHOT, no class is generated
  I use a workaround: I force the using vertx-codegen and vertx-service-proxy 3.5.4
  
  2) During the unit test, a NPE occured on the awaitResult() method, at line 50, from Sync class.
  I'am with the vertx-sync last snapshot with quasar-core 0.7.10 and quasar-maven-plugin 0.7.9
  Why this error ?
  
Below, the stack trace :

```
Caused by: io.vertx.core.VertxException: io.vertx.core.VertxException: java.lang.NullPointerException
        at io.vertx.ext.sync.Sync.awaitResult(Sync.java:50)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.lambda$onStarting$986b261$1(DaoSyncVerticle.java:56)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:44)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:32)
        at co.paralleluniverse.fibers.Fiber.run(Fiber.java:1097)
        at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092)
        at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788)
        at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100)
        at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91)
        at io.vertx.ext.sync.Sync.lambda$getContextScheduler$2(Sync.java:202)
        at co.paralleluniverse.fibers.FiberExecutorScheduler.execute(FiberExecutorScheduler.java:85)
        at co.paralleluniverse.fibers.RunnableFiberTask.submit(RunnableFiberTask.java:296)
        at co.paralleluniverse.fibers.RunnableFiberTask.unpark(RunnableFiberTask.java:274)
        at co.paralleluniverse.fibers.Fiber.unpark(Fiber.java:1352)
        at co.paralleluniverse.fibers.FiberAsync.fire(FiberAsync.java:366)
        at co.paralleluniverse.fibers.FiberAsync.asyncFailed(FiberAsync.java:344)
        at io.vertx.ext.sync.impl.AsyncAdaptor.handle(AsyncAdaptor.java:18)
        at io.vertx.ext.sync.impl.AsyncAdaptor.handle(AsyncAdaptor.java:11)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.createMongoCollectionsAndCreateIndexesIfNeeded(DaoSyncVerticle.java:133)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.lambda$null$0(DaoSyncVerticle.java:56)
        at io.vertx.ext.sync.Sync$1.requestAsync(Sync.java:43)
        at co.paralleluniverse.fibers.FiberAsync$1.run(FiberAsync.java:128)
        at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:824)
        at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100)
        at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91)
        at io.vertx.ext.sync.Sync.lambda$getContextScheduler$2(Sync.java:202)
        at co.paralleluniverse.fibers.FiberExecutorScheduler.execute(FiberExecutorScheduler.java:85)
        at co.paralleluniverse.fibers.RunnableFiberTask.submit(RunnableFiberTask.java:296)
        at co.paralleluniverse.fibers.Fiber.start(Fiber.java:1129)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.onStarting(DaoSyncVerticle.java:59)
        at io.vertx.ext.sync.npe.verticle.AbstractSyncVerticle.lambda$start$bd183658$1(AbstractSyncVerticle.java:37)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:44)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:32)
        at co.paralleluniverse.fibers.Fiber.run(Fiber.java:1097)
        at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092)
        at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788)
        at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100)
        at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91)
        at io.vertx.ext.sync.Sync.lambda$getContextScheduler$2(Sync.java:202)
        at co.paralleluniverse.fibers.FiberExecutorScheduler.execute(FiberExecutorScheduler.java:85)
        at co.paralleluniverse.fibers.RunnableFiberTask.submit(RunnableFiberTask.java:296)
        at co.paralleluniverse.fibers.Fiber.start(Fiber.java:1129)
        at io.vertx.ext.sync.npe.verticle.AbstractSyncVerticle.start(AbstractSyncVerticle.java:43)
        at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:494)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:464)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
Caused by: io.vertx.core.VertxException: java.lang.NullPointerException
        at io.vertx.ext.sync.Sync.awaitResult(Sync.java:50)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.createMongoCollectionsAndCreateIndexesIfNeeded(DaoSyncVerticle.java:120)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.lambda$null$0(DaoSyncVerticle.java:56)
        at io.vertx.ext.sync.Sync$1.requestAsync(Sync.java:43)
        at co.paralleluniverse.fibers.FiberAsync$1.run(FiberAsync.java:128)
        at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:824)
        at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100)
        at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91)
        at io.vertx.ext.sync.Sync.lambda$getContextScheduler$2(Sync.java:202)
        at co.paralleluniverse.fibers.FiberExecutorScheduler.execute(FiberExecutorScheduler.java:85)
        at co.paralleluniverse.fibers.RunnableFiberTask.submit(RunnableFiberTask.java:296)
        at co.paralleluniverse.fibers.Fiber.start(Fiber.java:1129)
        at io.vertx.ext.sync.npe.verticle.DaoSyncVerticle.onStarting(DaoSyncVerticle.java:59)
        at io.vertx.ext.sync.npe.verticle.AbstractSyncVerticle.lambda$start$bd183658$1(AbstractSyncVerticle.java:37)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:44)
        at co.paralleluniverse.strands.SuspendableUtils$VoidSuspendableCallable.run(SuspendableUtils.java:32)
        at co.paralleluniverse.fibers.Fiber.run(Fiber.java:1097)
        at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092)
        at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788)
        at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100)
        at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91)
        at io.vertx.ext.sync.Sync.lambda$getContextScheduler$2(Sync.java:202)
        at co.paralleluniverse.fibers.FiberExecutorScheduler.execute(FiberExecutorScheduler.java:85)
        at co.paralleluniverse.fibers.RunnableFiberTask.submit(RunnableFiberTask.java:296)
        at co.paralleluniverse.fibers.Fiber.start(Fiber.java:1129)
        at io.vertx.ext.sync.npe.verticle.AbstractSyncVerticle.start(AbstractSyncVerticle.java:43)
        at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:494)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:464)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```
		
		
Thanks for your help,
Fabien